### PR TITLE
Fix added for retries and sleep datatype.

### DIFF
--- a/rancher_upgrader/rancher_upgrader.py
+++ b/rancher_upgrader/rancher_upgrader.py
@@ -252,8 +252,8 @@ def main():
         rancher_url=parsed.RANCHER_URL,
         rancher_access_key=parsed.RANCHER_ACCESS_KEY,
         rancher_secret_key=parsed.RANCHER_SECRET_KEY,
-        retries=parsed.MAX_RETRIES,
-        sleep_time=parsed.SLEEP_TIME
+        retries=int(parsed.MAX_RETRIES),
+        sleep_time=int(parsed.SLEEP_TIME)
     )
 
     try:

--- a/rancher_upgrader/rancher_upgrader.py
+++ b/rancher_upgrader/rancher_upgrader.py
@@ -239,7 +239,6 @@ def main():
     extra_opt.add_argument('--sleep',
                            dest="SLEEP_TIME",
                            help="sleep time while checking upgrading process",
-                           action="store_true",
                            default=5)
 
     parsed = parser.parse_args()


### PR DESCRIPTION
Fix added for retries and sleep datatype issue ['--retires' option causing exception, 'str' object cannot be interpreted as an integer](https://github.com/cr0hn/rancher-upgrader/issues/1).